### PR TITLE
button panel without magicgui

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,8 @@ Set up a conda environment with all dependencies and activate it:
 conda create -c conda-forge -n test-annotations napari scikit-image h5py pandas
 conda activate test-annotations
 ```
-Then install magicgui and this tool using pip:
+Then install this tool using pip:
 ```
-pip install magicgui
 pip install -e .
 ```
 

--- a/napari_covid_if_annotations/gui.py
+++ b/napari_covid_if_annotations/gui.py
@@ -1,64 +1,34 @@
 import os
-from magicgui import magicgui, register_type
-from napari import Viewer
-from qtpy import QtWidgets
-from ._key_bindings import (update_layers,
-                            toggle_hide_annotated_segments,
-                            paint_new_label,
-                            _save_labels)
-
-#
-# additional gui elements
-#
-
-
-def get_viewers(gui, *args):
-    try:
-        viewer = gui.parent().qt_viewer.viewer
-        return (viewer,)
-    except AttributeError:
-        return tuple(v for v in globals().values() if isinstance(v, Viewer))
-
-
-register_type(Viewer, choices=get_viewers)
-
-
-# TODO expose the partial parameter to the gui
-@magicgui(call_button='save annotations [shfit + s]', viewer={'visible': False})
-def save_gui(viewer: Viewer):
-    _save_labels(viewer)
-
-
-@magicgui(call_button='update layers [u]', viewer={"visible": False})
-def update_layers_gui(viewer: Viewer):
-    update_layers(viewer)
-
-
-@magicgui(call_button='hide annotated cells [h]', viewer={"visible": False})
-def toggle_hide_annotated_segments_gui(viewer: Viewer):
-    toggle_hide_annotated_segments(viewer)
-
-
-@magicgui(call_button='get next label [n]', viewer={"visible": False})
-def paint_new_label_gui(viewer: Viewer):
-    paint_new_label(viewer)
+from qtpy.QtWidgets import QLabel, QPushButton, QWidget, QVBoxLayout
+from ._key_bindings import (
+    update_layers,
+    toggle_hide_annotated_segments,
+    paint_new_label,
+    _save_labels,
+)
 
 
 def connect_to_viewer(viewer):
     """ Add all gui elements to the viewer
     """
 
-    # get gui buttons for the additional functionality
-    saving_gui = save_gui.Gui()
-    update_gui = update_layers_gui.Gui()
-    hide_gui = toggle_hide_annotated_segments_gui.Gui()
-    paint_gui = paint_new_label_gui.Gui()
+    save_gui_btn = QPushButton("save annotations [shfit + s]")
+    save_gui_btn.clicked.connect(lambda: _save_labels(viewer))
+
+    update_gui_btn = QPushButton("update layers [u]")
+    update_gui_btn.clicked.connect(lambda: update_layers(viewer))
+
+    hide_gui_btn = QPushButton("hide annotated cells [h]")
+    hide_gui_btn.clicked.connect(lambda: toggle_hide_annotated_segments(viewer))
+
+    paint_gui_btn = QPushButton("get next label [n]")
+    paint_gui_btn.clicked.connect(lambda: paint_new_label(viewer))
 
     # make a tooltop about the label colors
-    tooltip = QtWidgets.QLabel()
+    tooltip = QLabel()
 
     # TODO see if we can get this working
-    im_file = os.path.join(os.path.split(__file__)[0], 'images', 'placeholder.png')
+    im_file = os.path.join(os.path.split(__file__)[0], "images", "placeholder.png")
     if os.path.exists(im_file):
         qimage = None
         tooltip.setPicture(qimage)
@@ -69,15 +39,16 @@ def connect_to_viewer(viewer):
         tooltip.setText(qtext)
 
     # merge all the gui elements
-    my_gui = QtWidgets.QWidget()
-    layout = QtWidgets.QVBoxLayout()
+    my_gui = QWidget()
+    layout = QVBoxLayout()
 
     my_gui.setLayout(layout)
     layout.addWidget(tooltip)
-    layout.addWidget(update_gui)
-    layout.addWidget(hide_gui)
-    layout.addWidget(paint_gui)
-    layout.addWidget(saving_gui)
+    layout.addWidget(update_gui_btn)
+    layout.addWidget(hide_gui_btn)
+    layout.addWidget(paint_gui_btn)
+    layout.addWidget(save_gui_btn)
+    layout.addStretch()
 
     # add them to the viewer
-    viewer.window.add_dock_widget(my_gui, area='right', allowed_areas=['right', 'left'])
+    viewer.window.add_dock_widget(my_gui, area="right", allowed_areas=["right", "left"])

--- a/napari_covid_if_annotations/gui.py
+++ b/napari_covid_if_annotations/gui.py
@@ -1,5 +1,5 @@
 import os
-from qtpy.QtWidgets import QLabel, QPushButton, QWidget, QVBoxLayout
+from qtpy.QtWidgets import QLabel, QPushButton
 from ._key_bindings import (
     update_layers,
     toggle_hide_annotated_segments,
@@ -38,17 +38,8 @@ def connect_to_viewer(viewer):
         qtext += "<br><font color='cyan'>Control</font> <br> <font color='yellow'>Uncertain</font>"
         tooltip.setText(qtext)
 
-    # merge all the gui elements
-    my_gui = QWidget()
-    layout = QVBoxLayout()
-
-    my_gui.setLayout(layout)
-    layout.addWidget(tooltip)
-    layout.addWidget(update_gui_btn)
-    layout.addWidget(hide_gui_btn)
-    layout.addWidget(paint_gui_btn)
-    layout.addWidget(save_gui_btn)
-    layout.addStretch()
-
-    # add them to the viewer
-    viewer.window.add_dock_widget(my_gui, area="right", allowed_areas=["right", "left"])
+    viewer.window.add_dock_widget(
+        [tooltip, update_gui_btn, hide_gui_btn, paint_gui_btn, save_gui_btn],
+        area="right",
+        allowed_areas=["right", "left"],
+    )


### PR DESCRIPTION
Here's a much simpler way of connecting buttons to the viewer on the right...  I think magicgui is more trouble than it's worth in this case!

Note: if you liked the buttons being spaced out as they were before (rather than grouped at the top as they are in this PR), then you can build the layout yourself like this:

```python
    # merge all the gui elements
    my_gui = QWidget()
    layout = QVBoxLayout()

    my_gui.setLayout(layout)
    layout.addWidget(tooltip)
    layout.addWidget(update_gui_btn)
    layout.addWidget(hide_gui_btn)
    layout.addWidget(paint_gui_btn)
    layout.addWidget(save_gui_btn)

    # add them to the viewer
    viewer.window.add_dock_widget(my_gui, area="right", allowed_areas=["right", "left"])
```