### PR TITLE
improve hiding

### DIFF
--- a/napari_covid_if_annotations/_key_bindings.py
+++ b/napari_covid_if_annotations/_key_bindings.py
@@ -31,13 +31,13 @@ def update_infected_labels_from_points(point_labels, infected_labels):
     return np.array([0] + point_labels.tolist())
 
 
-# TODO we should also disable removing all the layers!
 def modify_points_layer(viewer):
     control_widgets = viewer.window.qt_viewer.controls.widgets
     # disable the add point button in the infected-vs-control layer
     points_controls = control_widgets[viewer.layers['infected-vs-control']]
     points_controls.addition_button.setEnabled(False)
     points_controls.select_button.setEnabled(False)
+    points_controls.delete_button.setEnabled(False)
 
 
 #
@@ -110,8 +110,10 @@ def update_layers(viewer):
         # make sure all alpha values are set to 1, in order to properly toggle visibility
         viewer.layers['infected-vs-control'].edge_color_cycle[1:, -1] = 1
         viewer.layers['infected-vs-control'].face_color_cycle[1:, -1] = 1
-    viewer.layers['infected-vs-control'].refresh_colors()
-    
+
+    if viewer.layers['infected-vs-control'].visible:
+        viewer.layers['infected-vs-control'].refresh_colors()
+
     edge_width = viewer.layers['cell-outlines'].metadata['edge_width']
     edges = get_edge_segmentation(seg, edge_width)
     infected_edges = map_labels_to_edges(edges, seg_ids, infected_labels, hidden_segments, remap_background=4)
@@ -126,6 +128,7 @@ def toggle_hide_annotated_segments(viewer):
     viewer.layers['cell-segmentation'].metadata = metadata
     update_layers(viewer)
     viewer._hide_gui_btn.setChecked(metadata['hide_annotated_segments'])
+
 
 #
 # keybindings for toggling the labels of the point layer
@@ -162,6 +165,7 @@ def next_label(layer, event=None):
     layer.face_color[layer._value, -1] = 1
     layer.edge_color[layer._value, -1] = 1
     layer.refresh()
+
 
 def next_on_click(layer, event):
     """Mouse click binding to advance the label of the point under cursor"""

--- a/napari_covid_if_annotations/gui.py
+++ b/napari_covid_if_annotations/gui.py
@@ -1,5 +1,5 @@
 import os
-from qtpy.QtWidgets import QLabel, QPushButton
+from qtpy.QtWidgets import QLabel, QPushButton, QCheckBox
 from ._key_bindings import (
     update_layers,
     toggle_hide_annotated_segments,
@@ -18,8 +18,13 @@ def connect_to_viewer(viewer):
     update_gui_btn = QPushButton("update layers [u]")
     update_gui_btn.clicked.connect(lambda: update_layers(viewer))
 
-    hide_gui_btn = QPushButton("hide annotated cells [h]")
-    hide_gui_btn.clicked.connect(lambda: toggle_hide_annotated_segments(viewer))
+    def hide_toggle(hide_gui_btn, viewer):
+        hide = viewer.layers['cell-segmentation'].metadata['hide_annotated_segments']
+        if hide_gui_btn.isChecked() != hide:
+            toggle_hide_annotated_segments(viewer)
+    hide_gui_btn = QCheckBox("hide annotated cells")
+    hide_gui_btn.toggled.connect(lambda: hide_toggle(hide_gui_btn, viewer))
+    viewer._hide_gui_btn = hide_gui_btn
 
     paint_gui_btn = QPushButton("get next label [n]")
     paint_gui_btn.clicked.connect(lambda: paint_new_label(viewer))

--- a/napari_covid_if_annotations/gui.py
+++ b/napari_covid_if_annotations/gui.py
@@ -22,7 +22,7 @@ def connect_to_viewer(viewer):
         hide = viewer.layers['cell-segmentation'].metadata['hide_annotated_segments']
         if hide_gui_btn.isChecked() != hide:
             toggle_hide_annotated_segments(viewer)
-    hide_gui_btn = QCheckBox("hide annotated cells")
+    hide_gui_btn = QCheckBox("hide annotated cells [h]")
     hide_gui_btn.toggled.connect(lambda: hide_toggle(hide_gui_btn, viewer))
     viewer._hide_gui_btn = hide_gui_btn
 

--- a/napari_covid_if_annotations/launcher/covid_if_annotations.py
+++ b/napari_covid_if_annotations/launcher/covid_if_annotations.py
@@ -67,18 +67,21 @@ def launch_covid_if_annotation_tool(path=None, saturation_factor=1, edge_width=2
                     if len([ll for ll in layers if isinstance(ll, Points)]) > 1:
                         replace_layer(event.item, layers, 'infected-vs-control')
 
-                    # modifty the new points layer
-                    viewer.layers['infected-vs-control'].refresh_colors()
-                    modify_points_layer(viewer)
-
                     # select the new points layer
                     layer = viewer.layers['infected-vs-control']
                     viewer.layers.unselect_all()
                     layer.selected = True
 
-                # add the 'change label on click' functionality to the points layer
-                if isinstance(event.item, Points) and event.type == 'added':
+                    # modifty the new points layer
+                    viewer.layers['infected-vs-control'].refresh_colors()
+
+                    # add the 'change label on click' functionality to the points layer
                     event.item.mouse_drag_callbacks.append(next_on_click)
+
+                # always modify the points layer to deactivate the buttons we don't need
+                if isinstance(event.item, Points):
+                    modify_points_layer(viewer)
+
             except AttributeError:
                 pass
 

--- a/napari_covid_if_annotations/layers.py
+++ b/napari_covid_if_annotations/layers.py
@@ -26,6 +26,7 @@ def get_centroid_kwargs(centroids, infected_labels):
     label_names = ['unlabeled', 'infected', 'control', 'uncertain']
     labels = [0, 1, 2, 3]
     face_color_cycle = ['white', 'red', 'cyan', 'yellow']
+    edge_color_cycle = ['black', 'black', 'black', 'black']
 
     properties = get_centroid_properties(centroids, infected_labels)
     centroid_kwargs = {
@@ -33,8 +34,8 @@ def get_centroid_kwargs(centroids, infected_labels):
         'properties': properties,
         'size': 15,
         'edge_width': 5,
-        'edge_color': 'black',
-        'edge_colormap': 'gray',
+        'edge_color': 'cell_type',
+        'edge_color_cycle': edge_color_cycle,
         'face_color': 'cell_type',
         'face_color_cycle': face_color_cycle,
         'metadata': {'labels': labels,


### PR DESCRIPTION
This PR closes #24, but maybe reintroduces the bug in #23.

It adds a checkbox for the hide functionality, note though one has to do some pretty unpleasant attachment of the Qt checkbox onto the viewer to synchronize a keypress with the button, maybe we should revisit how napari handles this

it also makes drops the lightblue highlight for the vispy points layer. in the future that will be a config setting, but for now i just overwrite a width. one could also make it a property on the layer

i've now set up the colorings such that when in hide mode the colors of the annotated points change their opacity. again maybe a better way to do this in the future, and curious what @kevinyamauchi thinks of this (see #24 and #23 for context).

![covid_annotator1](https://user-images.githubusercontent.com/6531703/83359746-12a8d180-a331-11ea-9ad7-bd2a5946521f.gif)

Feel free to completely take over/ ignore / overwrite any of this PR. Absolutely fine for you to copy and paste bits you want into your own PR or make direct edits to it - you should have necessary permissions to do so