### PR TITLE
Bumpversion versioning

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,25 @@
+[bumpversion]
+current_version = 0.0.3dev1
+commit = False
+tag = False
+tag_name = {new_version}
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<build>\d+))?
+serialize = 
+    {major}.{minor}.{patch}{release}{build}
+    {major}.{minor}.{patch}
+
+[bumpversion:part:release]
+first_value = dev
+optional_value = release
+values = 
+    dev
+    release
+    post
+
+[bumpversion:part:build]
+first_value = 1
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:napari_covid_if_annotations/_version.py]
+

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,3 @@ target/
 
 # OS
 .DS_Store
-
-# written by setuptools_scm
-*/_version.py

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,53 @@
+# Development
+
+## Create a development environment
+
+```bash
+conda env create --file dev/environment-dev.py
+conda activate covid-if-dev
+conda install --file requirements.txt
+```
+
+This will create an environment with the name `covid-if-dev`, that can be activated with `conda activate covid-if-dev`.
+
+## Automatic versioning with bumpversion
+
+The following versioning scheme is implemented `<major>.<minor>.<patch><release-type><build>`.
+`major`, `minor`, and `patch` shouldn't need more introduction.
+The only _special_ thing here is the `release-type` with its `build`.
+`release-type` will take the value of `dev` as a default and the `build` is a simple counter.
+
+```
+1.2.3dev4
+^ ^ ^ ^ ^     command                 result
+| | | | |
+| | | | +--+ `bumpversion build`   -> 1.2.3dev5
+| | | |
+| | | +----+ `bumpversion release` -> 1.2.3
+| | |        `bumpversion release` -> 1.2.3post1
+| | |
+| | +------+ `bumpversion patch`   -> 1.2.4dev1
+| |
+| +--------+ `bumpversion minor`   -> 1.3.0dev1
+|
++----------+ `bumpversion major`   -> 2.0.0dev1
+
+```
+
+## Dependency management
+
+There are two different types of dependencies:
+
+1) Package dependencies for deployment:
+   These dependencies should be added to your project's `setup.py` under the requirements section.
+   These packages are automatically added to the conda recipe in `conda-recipe/meta.yaml`. 
+2) Development dependencies
+   Package dependencies in this repository are managed in `requirements.txt`.
+   All additional packages that are needed for development/building, should be added to your package's `dev/environment-dev.yaml`.
+
+## Black style checking / pre-commit
+
+This repo comes with a `.pre-commit-config.yaml` that allows for convenient automatic use of the [black](https://github.com/ambv/black) code formatter.
+Black will be run before every commit.
+In case reformatting is necessary, the commit action is aborted.
+Reformatted changes have to be added and the commit has to be triggered again.

--- a/dev/environment-dev.yaml
+++ b/dev/environment-dev.yaml
@@ -1,0 +1,11 @@
+name: covid-if-dev
+channels:
+  - defaults
+  - conda-forge
+  - ilastik-forge
+dependencies:
+  - anaconda-client
+  - bumpversion
+  - conda-build
+  - conda-verify
+  - yaml

--- a/napari_covid_if_annotations/_version.py
+++ b/napari_covid_if_annotations/_version.py
@@ -1,0 +1,1 @@
+version = "0.0.3dev1"

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,6 @@ with open('requirements.txt') as f:
             requirements.append(stripped)
 
 
-# https://github.com/pypa/setuptools_scm
-use_scm = {"write_to": "napari_covid_if_annotations/_version.py"}
-
 setup(
     name='napari-covid-if-annotations',
     author='Constantin Pape',
@@ -36,8 +33,7 @@ setup(
     packages=find_packages(),
     python_requires='>=3.6',
     install_requires=requirements,
-    use_scm_version=use_scm,
-    setup_requires=['setuptools_scm'],
+    version="0.0.3dev1",
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
switch from `setuptools_scm` to versioning via `bumpversion`. This makes making a release a bit more manual (but at the same time a bit more conscious).

What looks more complicated atm (and it is) simplifies deployment (where one has to add versions in multiple places, which of course in turn could be inferred from "the latest package found on ilastik-forge", but I prefer to be explicit about it.

I also added some dev notes in dev/README.md . 

basically you can bump the version by calling `bumpversion {major|minor|patch|release|build}`. Then in future the idea is to push this commit, and trigger ci upon pushing the appropriate tag, too (see future PRs).