### PR TITLE
Add deployment via CI on windows

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.3dev5
+current_version = 0.0.3dev6
 commit = False
 tag = False
 tag_name = {new_version}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+environment:
+  # set miniconda version explicitly
+  MINICONDA: C:\Miniconda37-x64
+  APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -xr!*/ -ir-!*.tar.bz2 -ir-!*.conda  # Exclude directories only cache downloaded tars
+
+cache:
+  - C:\Miniconda37-x64\pkgs -> appveyor.yml
+
+install:
+  - cmd: set "PATH=%MINICONDA%;%MINICONDA%\Scripts;%MINICONDA%\Library\bin;%PATH%
+  - cmd: where conda
+  - cmd: conda config --set always_yes yes --set changeps1 no --set channel_priority flexible
+  - cmd: conda update -q conda
+  - cmd: conda install -c conda-forge conda-build anaconda-client
+  - conda clean -p
+
+build_script:
+  - cmd: conda build -c kreshuklab -c conda-forge -c defaults --python=%PYTHON_VERSION%  conda-recipe
+
+before_test:
+  - cmd: conda install -c local -c kreshuklab -c conda-forge -c defaults covid-if-annotations
+
+test_script:
+  - cmd: covid_if_annotations --help
+
+# on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,12 @@ environment:
   # set miniconda version explicitly
   MINICONDA: C:\Miniconda37-x64
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -xr!*/ -ir-!*.tar.bz2 -ir-!*.conda  # Exclude directories only cache downloaded tars
+  matrix:
+    - PYTHON_VERSION: 3.6
+    - PYTHON_VERSION: 3.7
+
+matrix:
+  fast_finish: true
 
 cache:
   - C:\Miniconda37-x64\pkgs -> appveyor.yml
@@ -15,13 +21,18 @@ install:
   - conda clean -p
 
 build_script:
-  - cmd: conda build -c kreshuklab -c conda-forge -c defaults --python=%PYTHON_VERSION%  conda-recipe
+  - cmd: conda build -c kreshuklab -c conda-forge -c defaults python=%PYTHON_VERSION%  conda-recipe
 
 before_test:
-  - cmd: conda install -c local -c kreshuklab -c conda-forge -c defaults covid-if-annotations
+  - cmd: conda install -c local -c kreshuklab -c conda-forge -c defaults --python=%PYTHON_VERSION% covid-if-annotations
 
 test_script:
   - cmd: covid_if_annotations --help
+
+
+deploy_script:
+  - cmd: if NOT "%APPVEYOR_REPO_TAG_NAME%"=="" echo "would deploy"
+  - cmd: if NOT "%APPVEYOR_REPO_TAG_NAME%"=="" if "%PYTHON_VERSION%"=="3.7" echo "would deploy -> 2"
 
 # on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,10 +27,10 @@ install:
   - conda clean -p
 
 build_script:
-  - cmd: conda build -c kreshuklab -c conda-forge -c defaults python=%PYTHON_VERSION%  conda-recipe
+  - cmd: conda build -c kreshuklab -c conda-forge -c defaults --python=%PYTHON_VERSION%  conda-recipe
 
 before_test:
-  - cmd: conda install -c local -c kreshuklab -c conda-forge -c defaults --python=%PYTHON_VERSION% covid-if-annotations
+  - cmd: conda install -c local -c kreshuklab -c conda-forge -c defaults python=%PYTHON_VERSION% covid-if-annotations
 
 test_script:
   - cmd: covid_if_annotations --help

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ environment:
   # set miniconda version explicitly
   MINICONDA: C:\Miniconda37-x64
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -xr!*/ -ir-!*.tar.bz2 -ir-!*.conda  # Exclude directories only cache downloaded tars
+  ATOKEN:
+    secure: JBHpRgpIfeO7xURHDlchv42LaAS3JT9KCgkiz4f+o8kbGg5zbvXAGJRtkFDVVwqE
+
   matrix:
     - PYTHON_VERSION: 3.6
     - PYTHON_VERSION: 3.7
@@ -31,7 +34,7 @@ test_script:
 
 
 deploy_script:
-  - cmd: if NOT "%APPVEYOR_REPO_TAG_NAME%"=="" echo "would deploy"
+  - cmd: if NOT "%APPVEYOR_REPO_TAG_NAME%"=="" anaconda -t %ATOKEN% upload %MINICONDA%\conda-bld\win-64\covid-if-annotations-*.tar.bz2
   - cmd: if NOT "%APPVEYOR_REPO_TAG_NAME%"=="" if "%PYTHON_VERSION%"=="3.7" echo "would deploy -> 2"
 
 # on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ environment:
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -xr!*/ -ir-!*.tar.bz2 -ir-!*.conda  # Exclude directories only cache downloaded tars
   ATOKEN:
     secure: JBHpRgpIfeO7xURHDlchv42LaAS3JT9KCgkiz4f+o8kbGg5zbvXAGJRtkFDVVwqE
+  UPLD_A:
+    secure: 8z+FM88ZOdl+KUzKazD/MAI8HgncP4k6niGNvm7oykZefdUxsR5iWvaIkUjA5/LI
+  UPLD_U:
+    secure: Yk8a1hOcjeW7XP21YZNgRhhJN7uh3jKyvcPcEMyjacI=
 
   matrix:
     - PYTHON_VERSION: 3.6
@@ -17,7 +21,6 @@ cache:
 
 install:
   - cmd: set "PATH=%MINICONDA%;%MINICONDA%\Scripts;%MINICONDA%\Library\bin;%PATH%
-  - cmd: where conda
   - cmd: conda config --set always_yes yes --set changeps1 no --set channel_priority flexible
   - cmd: conda update -q conda
   - cmd: conda install -c conda-forge conda-build anaconda-client
@@ -32,10 +35,13 @@ before_test:
 test_script:
   - cmd: covid_if_annotations --help
 
+before_deploy:
+  - cmd: conda install -c conda-forge -c defaults curl constructor
 
 deploy_script:
   - cmd: if NOT "%APPVEYOR_REPO_TAG_NAME%"=="" anaconda -t %ATOKEN% upload %MINICONDA%\conda-bld\win-64\covid-if-annotations-*.tar.bz2
-  - cmd: if NOT "%APPVEYOR_REPO_TAG_NAME%"=="" if "%PYTHON_VERSION%"=="3.7" echo "would deploy -> 2"
+  - cmd: if NOT "%APPVEYOR_REPO_TAG_NAME%"=="" if "%PYTHON_VERSION%"=="3.7" constructor dev\deployment\win
+  - cmd: if NOT "%APPVEYOR_REPO_TAG_NAME%"=="" if "%PYTHON_VERSION%"=="3.7" curl -u %UPLD_U% -T covid-if-annotations-setup-%APPVEYOR_REPO_TAG_NAME%.exe %UPLD_A%covid-if-annotations-setup-%APPVEYOR_REPO_TAG_NAME%.exe
 
 # on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ test_script:
   - cmd: covid_if_annotations --help
 
 before_deploy:
-  - cmd: conda install -c conda-forge -c defaults curl constructor
+  - cmd: conda install -c conda-forge -c defaults curl constructor=3.0.0
 
 deploy_script:
   - cmd: if NOT "%APPVEYOR_REPO_TAG_NAME%"=="" anaconda -t %ATOKEN% upload %MINICONDA%\conda-bld\win-64\covid-if-annotations-*.tar.bz2

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     {% endfor %}
 requirements:
   build:
-    - python >=3.6
+    - python
     - pip
   run:
     - python

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: covid-if-annotations
-  version: 0.0.3dev5
+  version: 0.0.3dev6
 
 source:
   path: ..

--- a/dev/deployment/osx/make-release.sh
+++ b/dev/deployment/osx/make-release.sh
@@ -1,7 +1,7 @@
 set -e
 set -x
 
-RELEASE_VERSION=0.0.3dev5
+RELEASE_VERSION=0.0.3dev6
 
 echo "Creating app bundle for covid-if-annotations ${RELEASE_VERSION}"
 

--- a/dev/deployment/win/construct.yaml
+++ b/dev/deployment/win/construct.yaml
@@ -1,5 +1,5 @@
 name: covid-if-annotations
-version: 0.0.3dev5
+version: 0.0.3dev6
 
 attempt_hardlinks: True
 uninstall_name: uninstall-covid-if-annotations
@@ -9,13 +9,13 @@ channels:
   - http://conda.anaconda.org/conda-forge
   - http://conda.anaconda.org/kreshuklab
 
-installer_filename: covid-if-annotations-setup-0.0.3dev5.exe
+installer_filename: covid-if-annotations-setup-0.0.3dev6.exe
 
 menu_packages:
   - covid-if-annotations
 
 specs:
-  - covid-if-annotations =0.0.3dev5
+  - covid-if-annotations =0.0.3dev6
   - menuinst [win]
   - python =3.7
 

--- a/dev/deployment/win/construct.yaml
+++ b/dev/deployment/win/construct.yaml
@@ -7,7 +7,7 @@ uninstall_name: uninstall-covid-if-annotations
 channels:
   - http://repo.anaconda.com/pkgs/main/
   - http://conda.anaconda.org/conda-forge
-  - http://conda.anaconda.org/ilastik-forge
+  - http://conda.anaconda.org/kreshuklab
 
 installer_filename: covid-if-annotations-setup-0.0.3dev5.exe
 

--- a/napari_covid_if_annotations/_version.py
+++ b/napari_covid_if_annotations/_version.py
@@ -1,1 +1,1 @@
-version = "0.0.3dev5"
+version = "0.0.3dev6"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=find_packages(),
     python_requires='>=3.6',
     install_requires=requirements,
-    version="0.0.3dev5",
+    version="0.0.3dev6",
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Hello @constantinpape,

this PR has the binary deployment on windows. This will only deploy on tags and upload to a top secret spot (that I will of course share with you).

The deployment part is a bit ugly, but well...

I will later tag and insert a link to the build here, so that you can have a look at it. [link to build](https://ci.appveyor.com/project/k-dominik/covid-if-annotations/build/job/ttmehx3e01ud8y9o)

Note that I created a new conda channel - kreshuklab - because there were some package clashes with the ilastik forge one (tifffile...).

Before merging, I would remove all built packages and the last commit (the version bump).